### PR TITLE
[FEAT] 커스텀 예외 클래스 정의 & 전역 예외 핸들러 구현

### DIFF
--- a/src/main/java/com/gorogoro/gateway/exception/BaseException.java
+++ b/src/main/java/com/gorogoro/gateway/exception/BaseException.java
@@ -1,0 +1,24 @@
+package com.gorogoro.gateway.exception;
+
+import lombok.Getter;
+
+@Getter
+public class BaseException extends RuntimeException {
+    private final ErrorCode errorCode;
+
+    public BaseException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+
+    public BaseException(ErrorCode errorCode, String message) {
+        super(message);
+        this.errorCode = errorCode;
+    }
+
+    public BaseException(ErrorCode errorCode, Throwable cause) {
+        super(errorCode.getMessage(), cause);
+        this.errorCode = errorCode;
+    }
+}
+

--- a/src/main/java/com/gorogoro/gateway/exception/CustomGlobalExceptionHandler.java
+++ b/src/main/java/com/gorogoro/gateway/exception/CustomGlobalExceptionHandler.java
@@ -1,0 +1,95 @@
+package com.gorogoro.gateway.exception;
+
+import com.gorogoro.gateway.exception.code.GatewayErrorCode;
+import org.springframework.boot.autoconfigure.web.WebProperties;
+import org.springframework.boot.autoconfigure.web.reactive.error.AbstractErrorWebExceptionHandler;
+import org.springframework.boot.web.reactive.error.ErrorAttributes;
+import org.springframework.context.ApplicationContext;
+import org.springframework.core.annotation.Order;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.MediaType;
+import org.springframework.http.codec.ServerCodecConfigurer;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.BodyInserters;
+import org.springframework.web.reactive.function.server.RequestPredicates;
+import org.springframework.web.reactive.function.server.RouterFunction;
+import org.springframework.web.reactive.function.server.RouterFunctions;
+import org.springframework.web.reactive.function.server.ServerRequest;
+import org.springframework.web.reactive.function.server.ServerResponse;
+import org.springframework.web.server.ResponseStatusException;
+import reactor.core.publisher.Mono;
+
+@Component
+@Order(-2)
+public class CustomGlobalExceptionHandler extends AbstractErrorWebExceptionHandler {
+    public CustomGlobalExceptionHandler(ErrorAttributes errorAttributes,
+                                        WebProperties webProperties,
+                                        ApplicationContext applicationContext,
+                                        ServerCodecConfigurer configurer) {
+        super(errorAttributes, webProperties.getResources(), applicationContext);
+        this.setMessageWriters(configurer.getWriters());
+        this.setMessageReaders(configurer.getReaders());
+    }
+
+    // 모든 에러 요청을 renderErrorResponse 메서드로 연결
+    @Override
+    protected RouterFunction<ServerResponse> getRoutingFunction(ErrorAttributes errorAttributes) {
+        return RouterFunctions.route(RequestPredicates.all(), this::renderErrorResponse);
+    }
+
+    // 에러 응답 생성 로직
+    private Mono<ServerResponse> renderErrorResponse(ServerRequest request) {
+        // 발생한 실제 예외 객체 가져오기
+        Throwable throwable = getError(request);
+
+        // 예외 종류에 따른 에러 코드 분석
+        ErrorDetails errorDetails = analyzeException(throwable);
+
+        // 응답 바디 재구성
+        ErrorResponse errorResponse = ErrorResponse.of(errorDetails.code, errorDetails.message);
+
+        // JSON 응답 반환
+        return ServerResponse.status(errorDetails.status)
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(BodyInserters.fromValue(errorResponse));
+    }
+
+    private ErrorDetails analyzeException(Throwable error) {
+        // 사용자 정의 예외 처리
+        if (error instanceof BaseException ex) {
+            ErrorCode errorCode = ex.getErrorCode();
+            return new ErrorDetails(
+                    errorCode.getHttpStatus(),
+                    errorCode.getCode(),
+                    errorCode.getMessage()
+            );
+        } else if (error instanceof ResponseStatusException ex) {
+            ErrorCode errorCode = mapResponseStatusException(ex);
+
+            return new ErrorDetails(
+                    errorCode.getHttpStatus(),
+                    errorCode.getCode(),
+                    errorCode.getMessage()
+            );
+        } else {
+            ErrorCode errorCode = GatewayErrorCode.INTERNAL_SERVER_ERROR;
+            return new ErrorDetails(
+                    errorCode.getHttpStatus(),
+                    errorCode.getCode(),
+                    errorCode.getMessage()
+            );
+        }
+    }
+
+    private ErrorCode mapResponseStatusException(ResponseStatusException ex) {
+        return switch (ex.getStatusCode().value()) {
+            case 404 -> GatewayErrorCode.NOT_FOUND;
+            case 405 -> GatewayErrorCode.METHOD_NOT_ALLOWED;
+            case 400 -> GatewayErrorCode.BAD_REQUEST;
+            default -> GatewayErrorCode.INTERNAL_SERVER_ERROR;
+        };
+    }
+
+    private record ErrorDetails(HttpStatusCode status, String code, String message) {}
+}

--- a/src/main/java/com/gorogoro/gateway/exception/ErrorCode.java
+++ b/src/main/java/com/gorogoro/gateway/exception/ErrorCode.java
@@ -1,0 +1,9 @@
+package com.gorogoro.gateway.exception;
+
+import org.springframework.http.HttpStatus;
+
+public interface ErrorCode {
+    HttpStatus getHttpStatus();
+    String getCode();
+    String getMessage();
+}

--- a/src/main/java/com/gorogoro/gateway/exception/ErrorResponse.java
+++ b/src/main/java/com/gorogoro/gateway/exception/ErrorResponse.java
@@ -1,0 +1,27 @@
+package com.gorogoro.gateway.exception;
+
+import java.util.List;
+
+public record ErrorResponse(
+        String code,
+        String message,
+        List<FieldError> errors
+) {
+    // 상세 에러 정보를 담는 내부 레코드
+    public record FieldError(
+            String field,
+            String reason,
+            Object rejectedValue
+    ) {
+    }
+
+    // 1. 에러 목록이 있는 경우 (주로 @Valid 실패 시 사용)
+    public static ErrorResponse of(String code, String message, List<FieldError> errors) {
+        return new ErrorResponse(code, message, errors);
+    }
+
+    // 2. 에러 목록이 없는 경우 (일반 비즈니스 예외)
+    public static ErrorResponse of(String code, String message) {
+        return new ErrorResponse(code, message, List.of());
+    }
+}

--- a/src/main/java/com/gorogoro/gateway/exception/code/GatewayErrorCode.java
+++ b/src/main/java/com/gorogoro/gateway/exception/code/GatewayErrorCode.java
@@ -1,0 +1,21 @@
+package com.gorogoro.gateway.exception.code;
+
+import com.gorogoro.gateway.exception.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum GatewayErrorCode implements ErrorCode {
+    INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "GTW-0001", "유효하지 않은 토큰입니다."),
+    UNAUTHORIZED_ACCESS(HttpStatus.UNAUTHORIZED, "GTW-0002", "접근 권한이 없습니다."),
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "GTW-0003", "서버 내부 오류가 발생했습니다."),
+    BAD_REQUEST(HttpStatus.BAD_REQUEST, "GTW-0004", "잘못된 요청입니다."),
+    NOT_FOUND(HttpStatus.NOT_FOUND, "GTW-0005", "존재하지 않는 경로입니다."),
+    METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "GTW-0006", "허용되지 않은 HTTP 메서드입니다.");
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+}


### PR DESCRIPTION
<!-- PR 제목 : [Commit Type] PR_내용 -->
<!-- PR 내용의 경우, 이슈 제목을 그대로 써도 되고, 이슈에 언급되지 않은 내용까지 써주세용 -->
<!-- ex) [FEAT] 회원 API 구현 -->

## ✨ 요약
Gateway 서비스 내에서 발생하는 예외를 체계적으로 관리하고, 클라이언트에게 통일된 에러 응답을 제공하기 위해 커스텀 예외 클래스와 전역 예외 핸들러를 구현했습니다.

## 📝 작업 내용
- BaseException: 모든 커스텀 예외의 부모가 되는 기본 예외 클래스 추가 (RuntimeException 상속)
- ErrorCode: 에러 코드, 메시지, HTTP 상태 코드를 추상화한 인터페이스 정의
- GatewayErrorCode: Gateway 서비스에서 발생하는 구체적인 에러 코드를 정의한 Enum 구현
- ErrorResponse: 클라이언트에게 반환할 표준 에러 응답 DTO 정의
- CustomGlobalExceptionHandler: AbstractErrorWebExceptionHandler를 상속받아 전역적으로 예외를 감지하고 처리하는 핸들러 구현

## 💭 주의 사항
- CustomGlobalExceptionHandler는 Spring WebFlux 환경인 Gateway에 맞춰 구현되었습니다.

## 💡 리뷰 포인트
- CustomGlobalExceptionHandler에서 예외를 잡아 응답을 생성하는 로직(renderErrorResponse)이 적절한지 확인 부탁드립니다.
- BaseException과 ErrorCode 구조가 향후 확장에 용이한지 검토 바랍니다.

## ✅ 테스트
- [x] 로컬 빌드/실행
- [ ] 단위 테스트 추가/통과
- [ ] API 수동 테스트